### PR TITLE
Always on Top

### DIFF
--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Build
         run: ./gradlew build
       - name: Upload Unsigned Module
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: project-scan-endpoint-unsigned
           path: build/Project-Scan-Endpoint.unsigned.modl

--- a/designer/src/main/java/com/bwdesigngroup/ignition/project_scan/designer/DesignerPushNotificationListener.java
+++ b/designer/src/main/java/com/bwdesigngroup/ignition/project_scan/designer/DesignerPushNotificationListener.java
@@ -78,7 +78,8 @@ public class DesignerPushNotificationListener extends FilteredPushNotificationLi
 
     private Boolean showDialog() {
         ConfirmationDialog dialog = new ConfirmationDialog(IgnitionDesigner.getFrame());
-        dialog.setLocationRelativeTo(null);
+        dialog.setLocationRelativeTo(IgnitionDesigner.getFrame());
+        dialog.setAlwaysOnTop(true);
         dialog.setVisible(true);
         return dialog.isConfirmed();
     }

--- a/designer/src/main/java/com/bwdesigngroup/ignition/project_scan/designer/dialog/ConfirmationDialog.java
+++ b/designer/src/main/java/com/bwdesigngroup/ignition/project_scan/designer/dialog/ConfirmationDialog.java
@@ -14,31 +14,6 @@ public class ConfirmationDialog extends JDialog {
               owner != null ? owner.getGraphicsConfiguration() : null);
         
         initComponents();
-        
-        // Center on owner window and ensure visibility on correct screen
-        centerOnOwner(owner);
-    }
-
-    private void centerOnOwner(Frame owner) {
-        if (owner != null) {
-            // Get owner's screen and window bounds
-            GraphicsConfiguration gc = owner.getGraphicsConfiguration();
-            Rectangle screenBounds = gc.getBounds();
-            Rectangle ownerBounds = owner.getBounds();
-            
-            // Get our dialog's size
-            Dimension dialogSize = getSize();
-            
-            // Calculate center position relative to owner window
-            int x = ownerBounds.x + (ownerBounds.width - dialogSize.width) / 2;
-            int y = ownerBounds.y + (ownerBounds.height - dialogSize.height) / 2;
-            
-            // Ensure dialog stays within screen bounds
-            x = Math.max(screenBounds.x, Math.min(x, screenBounds.x + screenBounds.width - dialogSize.width));
-            y = Math.max(screenBounds.y, Math.min(y, screenBounds.y + screenBounds.height - dialogSize.height));
-            
-            setLocation(x, y);
-        }
     }
 
     private void initComponents() {

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   gateway:
-    image: bwdesigngroup/ignition-docker:8.1.44
+    image: bwdesigngroup/ignition-docker:8.1.47
     environment:
       DEVELOPER_MODE: Y
       GATEWAY_SYSTEM_NAME: project-scan


### PR DESCRIPTION
- Made update dialog always appear on top of designer window
- Works no matter what window your designer is on, can be on a different screen, your laptop screen etc.
- If you have VSCode open on top of your designer, when you save the dialog also appears on top of that but isn't focused allowing you to still make edits, but it always stays on top, which may be annoying? but we have the option to not show the dialog at all so dealers choice?